### PR TITLE
Use setuptools_scm to manage a single version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+thebeat/_version.py
+
 __pycache__/
 *.py[cod]
 .ipynb_checkpoints/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ graft docs/source/_static
 include docs/Makefile docs/make.bat
 
 global-exclude *.py[cod]
+prune docs/build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,8 +41,11 @@ packages = [
     "thebeat.resources"
 ]
 
-[tool.setuptools.dynamic]
-version = {attr = "thebeat.__version__"}
+[tool.setuptools_scm]
+write_to = "thebeat/_version.py"
+
+[tool.check-manifest]
+ignore = ["thebeat/_version.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/thebeat/__init__.py
+++ b/thebeat/__init__.py
@@ -18,4 +18,8 @@
 from . import _decorators, core, helpers, linguistic, music, resources, stats, utils, visualization
 from .core import Sequence, SoundSequence, SoundStimulus
 
-__version__ = '0.0.1.dev0'
+try:
+    from ._version import __version__
+except ImportError:
+    from setuptools_scm import get_version
+    __version__ = get_version(root='..', relative_to=__file__)


### PR DESCRIPTION
Worth it? What do you think?

Basically, this will avoid having 2 version numbers (which could go out of sync) in git tags and in `__init__.__version__`.