### PR TITLE
Do not ignore flake8's warning W505 on too long docstring line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,6 @@ filterwarnings = [
 [tool.flake8]
 max-line-length = 160
 max-doc-length = 100
-extend-ignore = [
-    "W505",
-]
 per-file-ignores = [
     "__init__.py:F401",
     "docs/source/conf.py:E402,E265",


### PR DESCRIPTION
TODO: Fix and shorten docstring line lengths, until all tests pass