### PR TITLE
Add Python 3.12 and 3.13 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
 
     name: Test • Python ${{ matrix.python-version }} • ${{ matrix.os }}
@@ -74,10 +74,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install package
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -23,10 +23,10 @@ jobs:
           fetch-depth: 0
           filter: tree:0
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
Blocked by Abjad not being available for 3.12 and 3.13 on PyPI. Let's track if this gets fixed.

See also #88