### PR TITLE
Rename optional dependency music_notation to music-notation

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,1 +1,1 @@
-.[music_notation]
+.[music-notation]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install .[music_notation]
+          pip install .[music-notation]
 
       - name: Install PortAudio and LilyPond (Linux)
         if: contains(matrix.os, 'ubuntu')
@@ -90,7 +90,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install .[music_notation]
+          pip install .[music-notation]
 
       - name: Install PortAudio, PulseAudio, and D-Bus
         run: |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note that if you want to use *thebeat*'s functionality for plotting musical nota
 you have to install it using:
 
 ```bash
-pip install 'thebeat[music_notation]'
+pip install 'thebeat[music-notation]'
 ```
 
 This will install *thebeat* with the optional dependencies [abjad](https://abjad.github.io)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -33,7 +33,7 @@ you have to install it using:
 
 .. code-block:: console
 
-    pip install 'thebeat[music_notation]'
+    pip install 'thebeat[music-notation]'
 
 This will install thebeat with the dependencies needed for plotting musical notation.
 These dependencies are `abjad <https://abjad.github.io>`_ and `Lilypond <https://lilypond.org>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = ["version"]
 "Source Code" = "https://github.com/Jellevanderwerff/thebeat"
 
 [project.optional-dependencies]
-music_notation = [
+music-notation = [
     "abjad ; python_version > '3.9'",
     "abjad<=3.4 ; python_version <= '3.9'",
     "lilypond; sys_platform != 'darwin' or platform_machine != 'arm64'"

--- a/thebeat/_decorators.py
+++ b/thebeat/_decorators.py
@@ -30,7 +30,7 @@ def requires_lilypond(f):
 
         if lilypond is None and not shutil.which('lilypond'):
             raise ImportError("This function or method requires lilypond for plotting notes. You can install this "
-                              "opional depencency with pip install 'thebeat[music_notation]'.\n"
+                              "opional depencency with pip install 'thebeat[music-notation]'.\n"
                               "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.")
 
         if lilypond is not None:

--- a/thebeat/core/soundstimulus.py
+++ b/thebeat/core/soundstimulus.py
@@ -331,7 +331,7 @@ class SoundStimulus:
         if abjad is None:
             raise ImportError(
                 "This function requires the abjad package. Install, for instance by typing "
-                "`pip install abjad` or `pip install thebeat[music_notation]` into your terminal.\n"
+                "`pip install abjad` or `pip install thebeat[music-notation]` into your terminal.\n"
                 "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
             )
 

--- a/thebeat/music.py
+++ b/thebeat/music.py
@@ -539,7 +539,7 @@ class Rhythm(thebeat.core.sequence.BaseSequence):
     ) -> tuple[plt.Figure, plt.Axes]:
         """
         Make a plot containing the musical notation of the rhythm. This function requires an installation of 'abjad' and
-        'lilypond'. You can install both through ``pip install 'thebeat[music_notation]'``.
+        'lilypond'. You can install both through ``pip install 'thebeat[music-notation]'``.
         For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.
 
         The plot is returned as a :class:`matplotlib.figure.Figure` and :class:`matplotlib.axes.Axes` object,
@@ -607,7 +607,7 @@ class Rhythm(thebeat.core.sequence.BaseSequence):
         if abjad is None:
             raise ImportError(
                 "This function requires the abjad package. Install, for instance by typing "
-                "`pip install abjad` or `pip install thebeat[music_notation]` into your terminal.\n"
+                "`pip install abjad` or `pip install thebeat[music-notation]` into your terminal.\n"
                 "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
             )
 
@@ -813,7 +813,7 @@ class Melody(thebeat.core.sequence.BaseSequence):
     Most of the functions require you to install `abjad <https://abjad.github.io/>`_. Please note that the
     current version of `abjad` requires Python 3.10. The last version that supported Python 3.8-3.9 is
     `this one <https://pypi.org/project/abjad/3.4/>`_. The correct version will be installed automatically
-    when you install `thebeat` with ``pip install thebeat[music_notation]``.
+    when you install `thebeat` with ``pip install thebeat[music-notation]``.
     For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.
     """
 
@@ -970,7 +970,7 @@ class Melody(thebeat.core.sequence.BaseSequence):
         if abjad is None:
             raise ImportError(
                 "This function requires the abjad package. Install, for instance by typing "
-                "`pip install abjad` or `pip install thebeat[music_notation]` into your terminal.\n"
+                "`pip install abjad` or `pip install thebeat[music-notation]` into your terminal.\n"
                 "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
             )
 
@@ -1105,7 +1105,7 @@ class Melody(thebeat.core.sequence.BaseSequence):
         if abjad is None:
             raise ImportError(
                 "This function requires the abjad package. Install, for instance by typing "
-                "`pip install abjad` or `pip install thebeat[music_notation]` into your terminal.\n"
+                "`pip install abjad` or `pip install thebeat[music-notation]` into your terminal.\n"
                 "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
             )
 

--- a/thebeat/utils.py
+++ b/thebeat/utils.py
@@ -137,7 +137,7 @@ def get_major_scale(tonic: str, octave: int) -> list:
     Note
     ----
     This function requires abjad to be installed. It can be installed with ``pip install abjad`` or
-    ``pip install thebeat[music_notation]``.
+    ``pip install thebeat[music-notation]``.
     For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.
 
     Parameters
@@ -156,7 +156,7 @@ def get_major_scale(tonic: str, octave: int) -> list:
     if abjad is None:
         raise ImportError(
             "This function requires the abjad package. Install, for instance by typing "
-            "`pip install abjad` or `pip install thebeat[music_notation]` into your terminal.\n"
+            "`pip install abjad` or `pip install thebeat[music-notation]` into your terminal.\n"
             "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
         )
 


### PR DESCRIPTION
Package names (and optional "extras") should officially have -s instead of _s. `pip` was already normalizing names anyway, so this should be backwards compatible and seamless for users. But this way at least we follow the relevant PEP.

See #82 (in particular, https://github.com/Jellevanderwerff/thebeat/issues/82#issuecomment-2103594693)