### PR TITLE
Fft makeover

### DIFF
--- a/thebeat/stats.py
+++ b/thebeat/stats.py
@@ -646,7 +646,7 @@ def fft_values(
 
     """
     # Calculate step size
-    step_size = unit_size / 1000  # TODO Is this true in each case? Seems dodgy
+    step_size = unit_size / 1000
 
     # Make a sequence of ones and zeroes
     timeseries = thebeat.helpers.sequence_to_binary(sequence, resolution=step_size)

--- a/thebeat/stats.py
+++ b/thebeat/stats.py
@@ -609,6 +609,11 @@ def fft_values(
     The number of cycles per unit can be interpreted as the beat frequency. For instance, 2 cycles for a unit size of
     1000 ms means a beat frequency of 2 Hz.
 
+    Note
+    ----
+    If a sequence ends with an event, the last event is not included in the calculation of the Fourier transform.
+    This is because the Fourier transform assumes that the sequence can be repeated indefinitely.
+
     Parameters
     ----------
     sequence
@@ -637,7 +642,8 @@ def fft_values(
 
     # Make a sequence of ones and zeroes
     timeseries = thebeat.helpers.sequence_to_binary(sequence, resolution=step_size)
-    duration = sequence.duration
+    timeseries = timeseries if sequence.end_with_interval is True else timeseries[:-1]
+    duration = len(timeseries) * step_size
     x_length = np.ceil(duration / step_size).astype(int)
 
     # Do the fft

--- a/thebeat/stats.py
+++ b/thebeat/stats.py
@@ -653,7 +653,7 @@ def fft_values(
     # Slice the data and take absolute values (we don't care about complex numbers)
     min_freq_index = np.min(np.where(xf > x_min)).astype(int) if x_min else None
     max_freq_index = np.min(np.where(xf > x_max)).astype(int) if x_max else None
-    yf = np.abs(yf[min_freq_index:max_freq_index])
+    yf = np.abs(yf[min_freq_index:max_freq_index])**2
     xf = xf[min_freq_index:max_freq_index]
 
     return xf, yf


### PR DESCRIPTION
In order:
* power is now returned (ff44117)
* dc offset removal has been added as an argument that defaults to True (offset removed; 41cbc1f)
* Nyquist was already implemented of course
* I don't see a difference between the two options actually. 