### PR TITLE
Drop support for Python 3.8 and 3.9, and unpin matplotlib<3.10 test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
 
     name: Test • Python ${{ matrix.python-version }} • ${{ matrix.os }}
@@ -61,10 +61,10 @@ jobs:
       - name: Run tests with pytest
         id: pytest
         run: |
-          pytest ${{ matrix.python-version == '3.11' && '--mpl --mpl-results-path=pytest_mpl_results/ --mpl-generate-summary=html' || '' }}
+          pytest ${{ matrix.python-version == '3.13' && '--mpl --mpl-results-path=pytest_mpl_results/ --mpl-generate-summary=html' || '' }}
 
       - name: Upload pytest-mpl results
-        if: failure() && matrix.python-version == '3.11' && steps.pytest.conclusion == 'failure'
+        if: failure() && matrix.python-version == '3.13' && steps.pytest.conclusion == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: pytest-mpl-results-${{ runner.os }}${{ matrix.os == 'macos-latest' && '_arm64' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
 
     name: Test • Python ${{ matrix.python-version }} • ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This will install *thebeat* with the optional dependencies [abjad](https://abjad
 and [Lilypond](https://lilypond.org).
 
 *thebeat* is actively tested on Linux, macOS, and Windows. We aim to provide support for all
-[supported versions](https://devguide.python.org/versions/) of Python (3.9 and higher).
+[supported versions](https://devguide.python.org/versions/) of Python (3.10 and higher).
 
 # Try directly via Binder
 If you first would like to try *thebeat*, or of you wish to use it in, for instance, an

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This will install *thebeat* with the optional dependencies [abjad](https://abjad
 and [Lilypond](https://lilypond.org).
 
 *thebeat* is actively tested on Linux, macOS, and Windows. We aim to provide support for all
-[supported versions](https://devguide.python.org/versions/) of Python (3.8 and higher).
+[supported versions](https://devguide.python.org/versions/) of Python (3.9 and higher).
 
 # Try directly via Binder
 If you first would like to try *thebeat*, or of you wish to use it in, for instance, an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Yannick Jadoul", email = "yannick.jadoul@gmail.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["music", "rhythm", "timing", "cognitive science"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -36,8 +36,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 music-notation = [
-    "abjad ; python_version > '3.9'",
-    "abjad<=3.4 ; python_version <= '3.9'",
+    "abjad",
     "lilypond; sys_platform != 'darwin' or platform_machine != 'arm64'"
 ]
 
@@ -60,8 +59,7 @@ ignore = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 filterwarnings = [
-    "error",
-    "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning"  # Matplotlib 3.9; fixed in 3.10, but not available for Python 3.9
+    "error"
 ]
 
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Yannick Jadoul", email = "yannick.jadoul@gmail.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["music", "rhythm", "timing", "cognitive science"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ ignore = [
 minversion = "6.0"
 filterwarnings = [
     "error",
-    "ignore:'imghdr' is deprecated:DeprecationWarning"
+    "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning"  # Matplotlib 3.9; fixed in 3.10, but not available for Python 3.9
 ]
 
 [tool.flake8]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,3 @@ pyarrow
 numpy>=2; python_version>="3.9"
 numpy<2; python_version<"3.9"
 lilypond<2.25; sys_platform != 'darwin' or platform_machine != 'arm64'
-
-matplotlib<3.10

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,5 @@ pytest
 pytest-mpl
 pyarrow
 
-numpy>=2; python_version>="3.9"
-numpy<2; python_version<"3.9"
+numpy>=2
 lilypond<2.25; sys_platform != 'darwin' or platform_machine != 'arm64'

--- a/thebeat/music.py
+++ b/thebeat/music.py
@@ -811,8 +811,9 @@ class Melody(thebeat.core.sequence.BaseSequence):
     :py:meth:`~Melody.generate_random_melody` method.
 
     Most of the functions require you to install `abjad <https://abjad.github.io/>`_. Please note that the
-    current version of `abjad` requires Python 3.10. The last version that supported Python 3.8-3.9 is
-    `this one <https://pypi.org/project/abjad/3.4/>`_. The correct version will be installed automatically
+    current version of `abjad` requires Python 3.12. The last version that supported Python 3.10-3.11 is
+    `Abjad 3.19 <https://pypi.org/project/abjad/3.19/>`_. The last version that supported Python 3.9 is
+    `Abjad 3.4 <https://pypi.org/project/abjad/3.4/>`_. The correct version will be installed automatically
     when you install `thebeat` with ``pip install thebeat[music-notation]``.
     For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.
     """

--- a/thebeat/music.py
+++ b/thebeat/music.py
@@ -611,16 +611,6 @@ class Rhythm(thebeat.core.sequence.BaseSequence):
                 "For more details, see https://thebeat.readthedocs.io/en/latest/installation.html."
             )
 
-        # Abjad 3.12 and lower use the NoteMaker class, which is deprecated in 3.13. This is a workaround for compatability with all versions.
-        # This because abjad 3.13 etc require Python 3.10.
-        try:
-            make_notes = abjad.makers.make_notes
-        except AttributeError:
-            note_maker = abjad.makers.NoteMaker()
-
-            def make_notes(*args):  # noqa: E306
-                return list(note_maker(*args))
-
         # Preliminaries
         time_signature = abjad.TimeSignature(self.time_signature)
         remove_footers = """\n\\paper {\nindent = 0\\mm\nline-width = 110\\mm\noddHeaderMarkup = ""\nevenHeaderMarkup = ""
@@ -646,7 +636,7 @@ class Rhythm(thebeat.core.sequence.BaseSequence):
 
         # loop over the pitch duration and whether it is a note or rest, and add to notes
         for pitch, duration, is_plyd in zip(pitches, durations, is_played):
-            note = make_notes(pitch, duration)[0] if is_plyd else abjad.Rest(duration)
+            note = abjad.makers.make_notes(pitch, duration)[0] if is_plyd else abjad.Rest(duration)
             notes.append(note)
 
         # plot the notes
@@ -812,8 +802,7 @@ class Melody(thebeat.core.sequence.BaseSequence):
 
     Most of the functions require you to install `abjad <https://abjad.github.io/>`_. Please note that the
     current version of `abjad` requires Python 3.12. The last version that supported Python 3.10-3.11 is
-    `Abjad 3.19 <https://pypi.org/project/abjad/3.19/>`_. The last version that supported Python 3.9 is
-    `Abjad 3.4 <https://pypi.org/project/abjad/3.4/>`_. The correct version will be installed automatically
+    `Abjad 3.19 <https://pypi.org/project/abjad/3.19/>`_. The correct version will be installed automatically
     when you install `thebeat` with ``pip install thebeat[music-notation]``.
     For more details, see https://thebeat.readthedocs.io/en/latest/installation.html.
     """
@@ -1458,16 +1447,6 @@ class Melody(thebeat.core.sequence.BaseSequence):
         return samples
 
     def _get_lp_from_events(self, key: str, time_signature: tuple):
-        # Abjad 3.12 and lower use the NoteMaker class, which is deprecated in 3.13. This is a workaround for compatability with all versions.
-        # This because abjad 3.13 etc require Python 3.10.
-        try:
-            make_notes = abjad.makers.make_notes
-        except AttributeError:
-            note_maker = abjad.makers.NoteMaker()
-
-            def make_notes(*args):  # noqa: E306
-                return list(note_maker(*args))
-
         time_signature = abjad.TimeSignature(time_signature)
         pitch = abjad.NamedPitchClass(key)
         key = abjad.KeySignature(pitch)
@@ -1507,7 +1486,7 @@ class Melody(thebeat.core.sequence.BaseSequence):
         for pitch_name, note_duration, is_played in zip(pitch_names, note_durations, is_played):
             if is_played is True:
                 pitch = abjad.NamedPitch(pitch_name)
-                note = make_notes(pitch, note_duration)[0]
+                note = abjad.makers.make_notes(pitch, note_duration)[0]
             else:
                 note = abjad.Rest(note_duration)
             notes.append(note)


### PR DESCRIPTION
This should fix all CI, except the issues related to #123 (i.e., in Python 3.12 and 3.13).

Fix for Python >=3.12 coming soon, in separate branch/PR.