### PR TITLE
Fix Abjad usage after 3.28 update

### DIFF
--- a/thebeat/core/soundstimulus.py
+++ b/thebeat/core/soundstimulus.py
@@ -338,10 +338,19 @@ class SoundStimulus:
         note_strings = re.split(r"([A-Z])([0-9]?)", note_str)
         note_strings = [string for string in note_strings if string != ""]
 
+        # In Abjad 3.26 and lower, these values were properties; now they are member functions.
+        # Abjad 2.28 requires at least Python 3.12; so this is a patch for backwards compatibility.
+        # Remove once support for 3.11 gets dropped.
+        def get_hertz(named_pitch):
+            try:
+                return named_pitch.hertz()
+            except TypeError:
+                return named_pitch.hertz
+
         if len(note_strings) == 1:
-            freq = abjad.NamedPitch(note_strings[0], octave=4).hertz
+            freq = get_hertz(abjad.NamedPitch(note_strings[0], octave=4))
         elif len(note_strings) == 2:
-            freq = abjad.NamedPitch(note_strings[0], octave=int(note_strings[1])).hertz
+            freq = get_hertz(abjad.NamedPitch(note_strings[0], octave=int(note_strings[1])))
         else:
             raise ValueError("Please provide a string of format 'G' or 'G4'.")
 

--- a/thebeat/helpers.py
+++ b/thebeat/helpers.py
@@ -36,11 +36,6 @@ from scipy.io import wavfile
 import thebeat.resources
 from thebeat._decorators import requires_lilypond
 
-try:
-    import abjad
-except ImportError:
-    abjad = None
-
 
 def all_possibilities(numbers: list, target: float) -> np.ndarray:
     """


### PR DESCRIPTION
Turns CI green again. See #123 for details.

This PR preserves backwards compatibility with previous <=3.26 Abjad versions, as well as >=3.28 (I expect the intermediate v3.27 to not work, but let's not worry about that?), so that we can keep providing Python 3.9, 3.10, 3.11 versions.

@Jellevanderwerff, let's discuss if this is what we want, or if there's a good case for dropping support for Abjad <3.28 (and thus Python <3.12).

Don't merge until
- [x] we figure that out,
- [x] we have another check on whether we didn't miss anything that isn't covered by the tests, and 
- [x] #124 gets merged and we rebase this PR on top of that.

After merging
- [x] rebase and merge all pending dependabot/pre-commit PRs (#118, #120, #121, #122), and
- [x] consider what to do with Lilypond wheels dependency (#97 and #126).