### PR TITLE
Add property for calculating median IOI

### DIFF
--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -72,6 +72,11 @@ def test_iois_property(rng):
     with pytest.raises(ValueError, match=r"Inter-onset intervals \(IOIs\) cannot be zero or negative"):
         seq.iois = [1, 2, 3, -1, 4, 5]
 
+    # test mean and median IOI
+    seq = thebeat.core.Sequence([500, 1000, 1500])
+    assert seq.mean_ioi == 1000
+    assert seq.median_ioi == 1000
+
 
 def test_onsets_property(rng):
     seq = thebeat.core.Sequence.generate_random_normal(10, 500, 25, rng=rng)

--- a/thebeat/core/sequence.py
+++ b/thebeat/core/sequence.py
@@ -142,6 +142,11 @@ class BaseSequence:
         return np.float64(np.mean(self.iois))
 
     @property
+    def median_ioi(self) -> np.float64:
+        """The median inter-onset interval (IOI)."""
+        return np.float64(np.median(self.iois))
+
+    @property
     def duration(self) -> np.float64:
         """Property that returns the summed total of the inter-onset intervals."""
         return np.float64(np.sum(self.iois))


### PR DESCRIPTION
There was a property for calculating the mean IOI in ``BaseSequence`` but none for calcuating the median.